### PR TITLE
added external web service call blocks_ranking_get_ranking

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -214,7 +214,7 @@ class blocks_ranking_external extends external_api {
                             //'picture' => new external_value(PARAM_RAW, 'picture', VALUE_DEFAULT, null),
                             'picture' => new external_value(PARAM_TEXT,'picture url'),
                             'name' => new external_value(PARAM_RAW, 'name'),
-                            'points' => new external_value(PARAM_INT, 'points'),                                                                                   
+                            'points' => new external_value(PARAM_FLOAT, 'points'),                                                                                   
 						)
 					)
 				),

--- a/classes/external.php
+++ b/classes/external.php
@@ -1,0 +1,228 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Ranking external api.
+ *
+ * @package    contrib
+ * @subpackage block_ranking
+ * @copyright  2016 J. Kalkhof <jerry@ccadapps.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @since      Moodle 3.1
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+require_once("$CFG->libdir/externallib.php");
+require_once($CFG->dirroot.'/blocks/ranking/lib.php');
+
+/**
+ * Ranking external functions and service definitions.
+ *
+ * @package    contrib
+ * @subpackage block_ranking
+ * @copyright  2016 J. Kalkhof <jerry@ccadapps.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @since      Moodle 3.1
+ */
+class blocks_ranking_external extends external_api {
+
+    /**
+     * Describes the parameters for get_databases_by_courses.
+     *
+     * @return external_external_function_parameters
+     * @since Moodle 2.9
+     */
+    public static function get_ranking_parameters() {
+    
+    	error_log('blocks/ranking/classes/external.php: get_ranking_parameters');
+    	
+    	
+        return new external_function_parameters (
+            array(
+                'courseids' => new external_multiple_structure(
+                    new external_value(PARAM_INT, 'course id', VALUE_REQUIRED),
+                    'Array of course ids', VALUE_DEFAULT, array()
+                ),
+            )
+        );
+    }
+
+    /**
+     * Returns a list of databases in a provided list of courses,
+     * if no list is provided all databases that the user can view will be returned.
+     *
+     * @param array $courseids the course ids
+     * @return array the database details
+     * @since Moodle 2.9
+     */
+    public static function get_ranking($courseids = array()) {
+        global $CFG;
+    	global $PAGE, $DB ,$USER;
+    	global $COURSE;
+    	global $OUTPUT;
+    	
+        $params = self::validate_parameters(self::get_ranking_parameters(), array('courseids' => $courseids));
+        $warnings = array();
+        
+        error_log('blocks/ranking/classes/external.php: get_ranking');
+
+        $mycourses = array();
+//         if (empty($params['courseids'])) {
+//             $mycourses = enrol_get_my_courses();
+//             $params['courseids'] = array_keys($mycourses);
+//         }
+
+        // Array to store the databases to return.
+        $arrdatabases = array();
+
+		$studentlist = array();
+		
+        // Ensure there are courseids to loop through.
+        if (!empty($params['courseids'])) {
+        	foreach ($params['courseids'] as $courseid) {
+        		error_log('blocks/ranking/classes/external.php: get_ranking courseid: '.$courseid);
+        	
+        		// from report.php
+        		$course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);
+        		
+        		error_log('blocks/ranking/classes/external.php: get_ranking coursename: '.$course->fullname);
+        	
+	        	require_login($courseid);
+				$context = context_course::instance($courseid);
+				
+        		$perpage = 100;
+        		$group = null;
+			
+				$userfields = user_picture::fields('u', array('username'));
+				$from = "FROM {user} u
+						INNER JOIN {role_assignments} a ON a.userid = u.id
+						LEFT JOIN {ranking_points} r ON r.userid = u.id AND r.courseid = :r_courseid
+						INNER JOIN {context} c ON c.id = a.contextid";
+
+				$where = "WHERE a.contextid = :contextid
+						AND a.userid = u.id
+						AND a.roleid = :roleid
+						AND c.instanceid = :courseid";
+
+				$params['contextid'] = $context->id;
+				$params['roleid'] = 5;
+				$params['courseid'] = $COURSE->id;
+				$params['r_courseid'] = $params['courseid'];
+
+				$order = "ORDER BY r.points DESC, u.firstname ASC
+						LIMIT " . $perpage;
+
+				if ($group) {
+					$from .= " INNER JOIN {groups_members} gm ON gm.userid = u.id AND gm.groupid = :groupid";
+					$params['groupid'] = $group;
+				}
+
+				$sql = "SELECT $userfields, r.points $from $where $order";
+
+				$students = array_values($DB->get_records_sql($sql, $params));        	
+        	
+        		error_log('blocks/ranking/classes/external.php: get_ranking students: '.count($students));
+        		
+        		// from lib.php : generate_table
+        		$data = $students;
+				$lastpos = 1;
+			    $lastpoints = current($data)->points;
+			    for ($i = 0; $i < count($data); $i++) {
+					if ($lastpoints > $data[$i]->points) {
+						$lastpos++;
+						$lastpoints = $data[$i]->points;
+					}			    
+
+					// user picture stuff
+					// https://docs.moodle.org/dev/Output_renderers
+					//$OUTPUT->user_picture($data[$i], array('size' => 24, 'alttext' => false)),
+					//$OUTPUT->user_picture($data[$i], array('courseid' => $courseid, 'link' => true)),							
+					//error_log(print_r($data[$i], true));								
+					
+					// prepare to get user icon url
+					$userid = $data[$i]->id;
+					$context = context_user::instance($userid);
+					$contextid = $context->id;					
+					$image = null;
+					
+					$url = moodle_url::make_pluginfile_url($contextid, 'user', 'icon', null, '/', $image);					
+					//error_log('url: '.$url);
+					// http://localhost/moodle/pluginfile.php/71/user/icon
+					
+					// position, picture, name, points
+			        $row = array(
+                        "position" => $lastpos,
+                        "picture" => urlencode($url),
+                        "name" => $data[$i]->firstname,
+                        "points" => $data[$i]->points ?: 0
+                    );
+                    			    
+					error_log('blocks/ranking/classes/external.php: get_ranking student['.$i.']: ');
+					//error_log(print_r($row, true));				
+					
+					$studentlist[] = $row;	
+			    }        		
+        	}
+        }
+      
+
+        $result = array();
+        $result['leaderboard'] = $studentlist;
+        $result['warnings'] = $warnings;
+        
+        //$attemptData = json_encode($result);
+        $attemptData = $result;
+        
+        return $attemptData;
+    }
+
+    /**
+     * Describes the get_databases_by_courses return value.
+     *
+     * @return external_single_structure
+     * @since Moodle 2.9
+     */
+    public static function get_ranking_returns() {
+
+		error_log('blocks/ranking/classes/external.php: get_ranking_returns');
+
+		//return new external_single_structure();
+		
+		//return new external_value(PARAM_RAW, 'trfdsaz');		
+		
+        return new external_single_structure(
+            array(
+
+                'leaderboard' => new external_multiple_structure(
+                    new external_single_structure(
+                        array(
+                            'position' => new external_value(PARAM_INT, 'position'),
+                            //'picture' => new external_value(PARAM_RAW, 'picture', VALUE_DEFAULT, null),
+                            'picture' => new external_value(PARAM_TEXT,'picture url'),
+                            'name' => new external_value(PARAM_RAW, 'name'),
+                            'points' => new external_value(PARAM_INT, 'points'),                                                                                   
+						)
+					)
+				),
+
+
+                'warnings' => new external_warnings(),
+            )
+        );
+    }
+
+}

--- a/db/services.php
+++ b/db/services.php
@@ -1,0 +1,39 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+/**
+ * Ranking external functions and service definitions.
+ *
+ * @package    contrib
+ * @subpackage block_ranking
+ * @copyright  2016 J. Kalkhof <jerry@ccadapps.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @since      Moodle 3.1
+ */
+
+$functions = array(
+
+    'blocks_ranking_get_ranking' => array(
+        'classname' => 'blocks_ranking_external',
+        'classpath'   => 'blocks/ranking/classes/external.php',
+        'methodname' => 'get_ranking',
+        'description' => 'Returns a list of students and rank.',
+        'type' => 'read',
+        'capabilities' => 'mod/data:viewentry',
+        'services' => array(MOODLE_OFFICIAL_MOBILE_SERVICE)
+    )
+);


### PR DESCRIPTION
Hi Willian,

I recently added a webservice feature to allow clients to get ranking data from the ranking block.
I tested it using a local moodle installation, and I'm submitting this pull request for your review.

sample curl call

```
curl -k -X GET 'http://localhost/moodle/webservice/rest/server.php?moodlewsrestformat=json&wsfunction=blocks_ranking_get_ranking&courseids%5B0%5D=3&wstoken=35dcf876378927fa8fd27fdb10c97352'
```

and the format looks something like this:

```
{
    "leaderboard": [
        {
            "name": "Admin",
            "picture": "http%3A%2F%2Flocalhost%2Fmoodle%2Fpluginfile.php%2F8%2Fuser%2Ficon",
            "points": 0,
            "position": 1
        },
        {
            "name": "firstname",
            "picture": "http%3A%2F%2Flocalhost%2Fmoodle%2Fpluginfile.php%2F130%2Fuser%2Ficon",
            "points": 0,
            "position": 1
        },
        {
            "name": "firstname",
            "picture": "http%3A%2F%2Flocalhost%2Fmoodle%2Fpluginfile.php%2F111%2Fuser%2Ficon",
            "points": 0,
            "position": 1
        },
        {
            "name": "student",
            "picture": "http%3A%2F%2Flocalhost%2Fmoodle%2Fpluginfile.php%2F38%2Fuser%2Ficon",
            "points": 0,
            "position": 1
        },
        {
            "name": "testfirstname1",
            "picture": "http%3A%2F%2Flocalhost%2Fmoodle%2Fpluginfile.php%2F71%2Fuser%2Ficon",
            "points": 0,
            "position": 1
        }
    ],
    "warnings": []
}
```

I hope this feature will be useful to the community, as I'm actively developing a moodle mobile client right now with this feature.

thanks
-Jerry
